### PR TITLE
Removed missing 'lang' attribute workaround

### DIFF
--- a/gsearch_solr/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/gsearch_solr/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -82,14 +82,6 @@
     </field>
   </xsl:template>
   
-  <!-- Temporary workaround to allow us to separate out the Arabic subjects -->
-  <xsl:template match="mods:subject[@authority='local']" mode="Tahrir">
-    <!-- mods_topic_ar_mt is created automatically for us -->
-    <field name="mods_topic_ar_ms">
-      <xsl:value-of select="mods:topic"/>
-    </field>
-  </xsl:template>
-
   <!--
     SECTION 3:
     


### PR DESCRIPTION
This is no longer needed now that our MODS to Solr conversions support the 'lang' attribute (and it actually messes the newer method up in a few cases).

https://jira.library.ucla.edu/browse/ISLAND-550
